### PR TITLE
chore: add unit test with grpc stubs

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -45,3 +45,5 @@ vertipads
 vertipad
 appenders
 tftpl
+openapi
+tempfile

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -89,9 +89,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.17"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -107,9 +107,9 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "sync_wrapper",
- "tokio",
  "tower",
  "tower-http",
  "tower-layer",
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
 dependencies = [
  "async-trait",
  "bytes",
@@ -128,6 +128,7 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -202,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87b30366b6766751277791b473b674f3bf7fb75696841c784a3eb7e7fbf44ee"
+checksum = "fa48fa079165080f11d7753fd0bc175b7d391f276b965fe4b55bfad67856e463"
 dependencies = [
  "chrono",
  "chrono-tz-build 0.1.0",
@@ -408,6 +409,15 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26879b63ac36ca5492918dc16f8c1e604b0f70f884fffbd3533f89953ab1991"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -713,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "memchr"
@@ -806,9 +816,9 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "openssl"
-version = "0.10.42"
+version = "0.10.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -841,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.77"
+version = "0.9.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
 dependencies = [
  "autocfg",
  "cc",
@@ -884,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1030,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0841812012b2d4a6145fae9a6af1534873c32aa67fff26bd09f8fa42c83f95a"
+checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1040,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8b442418ea0822409d9e7d047cbf1e7e9e1760b172bf9982cf29d517c93511"
+checksum = "e330bf1316db56b12c2bcfa399e8edddd4821965ea25ddb2c134b610b1c1c604"
 dependencies = [
  "bytes",
  "heck",
@@ -1169,7 +1179,6 @@ dependencies = [
 [[package]]
 name = "router"
 version = "0.1.0"
-source = "git+https://github.com/Arrow-air/lib-router.git#2bdac70970e4bd2e4f127c20e70748f4a756305f"
 dependencies = [
  "cargo-husky",
  "chrono",
@@ -1204,6 +1213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,9 +1238,9 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
 dependencies = [
  "serde_derive",
 ]
@@ -1242,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1322,7 +1337,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "svc-scheduler"
-version = "0.2.4-develop.0"
+version = "0.2.5-develop.3"
 dependencies = [
  "cargo-husky",
  "chrono",
@@ -1340,19 +1355,22 @@ dependencies = [
  "router",
  "rrule",
  "svc-storage-client-grpc",
+ "tempfile",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tonic-build",
  "tonic-health",
+ "tower",
  "uuid",
 ]
 
 [[package]]
 name = "svc-scheduler-client-grpc"
-version = "0.2.4-develop.0"
+version = "0.2.5-develop.3"
 dependencies = [
  "chrono",
- "chrono-tz 0.8.0",
+ "chrono-tz 0.8.1",
  "prost",
  "prost-types",
  "tokio",
@@ -1361,21 +1379,23 @@ dependencies = [
 
 [[package]]
 name = "svc-storage-client-grpc"
-version = "0.6.0-develop.0"
-source = "git+https://github.com/Arrow-air/svc-storage.git?branch=develop#3a625f7174df006682bbb384c16ec482c9e907c5"
+version = "0.8.1-develop.0"
 dependencies = [
+ "geo-types",
  "num-derive",
  "num-traits",
+ "ordered-float 3.4.0",
  "prost",
  "prost-types",
  "tonic",
+ "uuid",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1444,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -1485,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1521,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b9af819e54b8f33d453655bef9b9acc171568fb49523078d0cc4e7484200ec"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1553,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c6fd7c2581e36d63388a9e04c350c21beb7a8b059580b2e93993c526899ddc"
+checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,6 +1339,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "svc-scheduler"
 version = "0.2.5-develop.3"
 dependencies = [
+ "async-trait",
  "cargo-husky",
  "chrono",
  "chrono-tz 0.6.3",

--- a/client-grpc/examples/grpc.rs
+++ b/client-grpc/examples/grpc.rs
@@ -17,7 +17,7 @@ use tonic::Request;
 /// should receive a valid response from the server
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = SchedulerRpcClient::connect("http://[::1]:50051").await?;
+    let mut client = SchedulerRpcClient::connect("http://[::1]:50052").await?;
 
     let departure_time = Utc.ymd(2022, 10, 25).and_hms(15, 0, 0).timestamp();
 

--- a/client-grpc/src/grpc.rs
+++ b/client-grpc/src/grpc.rs
@@ -1,6 +1,5 @@
 /// QueryFlightRequest
-#[derive(Eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Clone, PartialEq, ::prost::Message)]
 pub struct QueryFlightRequest {
     /// is_cargo - true if cargo mission, false if people transport
     #[prost(bool, tag = "1")]
@@ -25,8 +24,7 @@ pub struct QueryFlightRequest {
     pub vertiport_arrive_id: ::prost::alloc::string::String,
 }
 /// QueryFlightPlan
-#[derive(Eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Clone, PartialEq, ::prost::Message)]
 pub struct QueryFlightPlan {
     /// id of the flight
     #[prost(string, tag = "1")]
@@ -84,24 +82,21 @@ pub struct QueryFlightPlan {
     pub estimated_distance: u32,
 }
 /// QueryFlightResponse
-#[derive(Eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Clone, PartialEq, ::prost::Message)]
 pub struct QueryFlightResponse {
     /// array/vector of flight items
     #[prost(message, repeated, tag = "1")]
     pub flights: ::prost::alloc::vec::Vec<QueryFlightPlan>,
 }
 /// Id type for passing id only requests
-#[derive(Eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Clone, PartialEq, ::prost::Message)]
 pub struct Id {
     /// id
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
 }
 /// ConfirmFlightResponse
-#[derive(Eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Clone, PartialEq, ::prost::Message)]
 pub struct ConfirmFlightResponse {
     /// id
     #[prost(string, tag = "1")]
@@ -114,8 +109,7 @@ pub struct ConfirmFlightResponse {
     pub confirmation_time: ::core::option::Option<::prost_types::Timestamp>,
 }
 /// CancelFlightResponse
-#[derive(Eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Clone, PartialEq, ::prost::Message)]
 pub struct CancelFlightResponse {
     /// id
     #[prost(string, tag = "1")]
@@ -133,12 +127,10 @@ pub struct CancelFlightResponse {
 /// Ready Request
 ///
 /// No arguments
-#[derive(Eq, Copy)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Copy, Clone, PartialEq, ::prost::Message)]
 pub struct ReadyRequest {}
 /// Ready Response
-#[derive(Eq, Copy)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Copy, Clone, PartialEq, ::prost::Message)]
 pub struct ReadyResponse {
     /// ready
     #[prost(bool, tag = "1")]
@@ -204,8 +196,8 @@ impl FlightPriority {
 /// Generated client implementations.
 pub mod scheduler_rpc_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     ///Scheduler service
     #[derive(Debug, Clone)]
     pub struct SchedulerRpcClient<T> {
@@ -250,9 +242,8 @@ pub mod scheduler_rpc_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             SchedulerRpcClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -275,76 +266,56 @@ pub mod scheduler_rpc_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryFlightRequest>,
         ) -> Result<tonic::Response<super::QueryFlightResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/grpc.SchedulerRpc/queryFlight",
-            );
+            let path = http::uri::PathAndQuery::from_static("/grpc.SchedulerRpc/queryFlight");
             self.inner.unary(request.into_request(), path, codec).await
         }
         pub async fn confirm_flight(
             &mut self,
             request: impl tonic::IntoRequest<super::Id>,
         ) -> Result<tonic::Response<super::ConfirmFlightResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/grpc.SchedulerRpc/confirmFlight",
-            );
+            let path = http::uri::PathAndQuery::from_static("/grpc.SchedulerRpc/confirmFlight");
             self.inner.unary(request.into_request(), path, codec).await
         }
         pub async fn cancel_flight(
             &mut self,
             request: impl tonic::IntoRequest<super::Id>,
         ) -> Result<tonic::Response<super::CancelFlightResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/grpc.SchedulerRpc/cancelFlight",
-            );
+            let path = http::uri::PathAndQuery::from_static("/grpc.SchedulerRpc/cancelFlight");
             self.inner.unary(request.into_request(), path, codec).await
         }
         pub async fn is_ready(
             &mut self,
             request: impl tonic::IntoRequest<super::ReadyRequest>,
         ) -> Result<tonic::Response<super::ReadyResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/grpc.SchedulerRpc/isReady",
-            );
+            let path = http::uri::PathAndQuery::from_static("/grpc.SchedulerRpc/isReady");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -23,9 +23,9 @@ openssl                 = "0.10"
 ordered-float           = "3.2"
 prost                   = "0.11"
 prost-types             = "0.11"
-router                  = { git = "https://github.com/Arrow-air/lib-router.git" }
+router                  = { path = "../../lib-router" }
 rrule                   = "0.10"
-svc-storage-client-grpc = { git = "https://github.com/Arrow-air/svc-storage.git", branch = "develop" }
+svc-storage-client-grpc = { path = "../../svc-storage/client-grpc" }
 tokio                   = { version = "1.20", features = ["full"] }
 tonic                   = "0.8"
 tonic-health            = "0.7"
@@ -33,6 +33,11 @@ uuid                    = "1.2"
 
 [build-dependencies]
 tonic-build = "0.8"
+
+[dev-dependencies]
+tempfile = "3.3.0"
+tower = { version = "0.4" }
+tokio-stream = { version = "0.1.8", features = ["net"] }
 
 [dev-dependencies.cargo-husky]
 default-features = false          # Disable features which are enabled by default

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,6 +30,7 @@ tokio                   = { version = "1.20", features = ["full"] }
 tonic                   = "0.8"
 tonic-health            = "0.7"
 uuid                    = "1.2"
+async-trait             = "0.1"
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/server/src/grpc.rs
+++ b/server/src/grpc.rs
@@ -1,6 +1,5 @@
 /// QueryFlightRequest
-#[derive(Eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Clone, PartialEq, ::prost::Message)]
 pub struct QueryFlightRequest {
     /// is_cargo - true if cargo mission, false if people transport
     #[prost(bool, tag = "1")]
@@ -25,8 +24,7 @@ pub struct QueryFlightRequest {
     pub vertiport_arrive_id: ::prost::alloc::string::String,
 }
 /// QueryFlightPlan
-#[derive(Eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Clone, PartialEq, ::prost::Message)]
 pub struct QueryFlightPlan {
     /// id of the flight
     #[prost(string, tag = "1")]
@@ -84,24 +82,21 @@ pub struct QueryFlightPlan {
     pub estimated_distance: u32,
 }
 /// QueryFlightResponse
-#[derive(Eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Clone, PartialEq, ::prost::Message)]
 pub struct QueryFlightResponse {
     /// array/vector of flight items
     #[prost(message, repeated, tag = "1")]
     pub flights: ::prost::alloc::vec::Vec<QueryFlightPlan>,
 }
 /// Id type for passing id only requests
-#[derive(Eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Clone, PartialEq, ::prost::Message)]
 pub struct Id {
     /// id
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
 }
 /// ConfirmFlightResponse
-#[derive(Eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Clone, PartialEq, ::prost::Message)]
 pub struct ConfirmFlightResponse {
     /// id
     #[prost(string, tag = "1")]
@@ -114,8 +109,7 @@ pub struct ConfirmFlightResponse {
     pub confirmation_time: ::core::option::Option<::prost_types::Timestamp>,
 }
 /// CancelFlightResponse
-#[derive(Eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Clone, PartialEq, ::prost::Message)]
 pub struct CancelFlightResponse {
     /// id
     #[prost(string, tag = "1")]
@@ -133,12 +127,10 @@ pub struct CancelFlightResponse {
 /// Ready Request
 ///
 /// No arguments
-#[derive(Eq, Copy)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Copy, Clone, PartialEq, ::prost::Message)]
 pub struct ReadyRequest {}
 /// Ready Response
-#[derive(Eq, Copy)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Eq, Copy, Clone, PartialEq, ::prost::Message)]
 pub struct ReadyResponse {
     /// ready
     #[prost(bool, tag = "1")]
@@ -225,7 +217,7 @@ pub mod scheduler_rpc_server {
             request: tonic::Request<super::ReadyRequest>,
         ) -> Result<tonic::Response<super::ReadyResponse>, tonic::Status>;
     }
-    ///Scheduler service
+    /// Scheduler service
     #[derive(Debug)]
     pub struct SchedulerRpcServer<T: SchedulerRpc> {
         inner: _Inner<T>,
@@ -245,10 +237,7 @@ pub mod scheduler_rpc_server {
                 send_compression_encodings: Default::default(),
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -276,10 +265,7 @@ pub mod scheduler_rpc_server {
         type Response = http::Response<tonic::body::BoxBody>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
-        fn poll_ready(
-            &mut self,
-            _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -288,23 +274,15 @@ pub mod scheduler_rpc_server {
                 "/grpc.SchedulerRpc/queryFlight" => {
                     #[allow(non_camel_case_types)]
                     struct queryFlightSvc<T: SchedulerRpc>(pub Arc<T>);
-                    impl<
-                        T: SchedulerRpc,
-                    > tonic::server::UnaryService<super::QueryFlightRequest>
-                    for queryFlightSvc<T> {
+                    impl<T: SchedulerRpc> tonic::server::UnaryService<super::QueryFlightRequest> for queryFlightSvc<T> {
                         type Response = super::QueryFlightResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::QueryFlightRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move {
-                                (*inner).query_flight(request).await
-                            };
+                            let fut = async move { (*inner).query_flight(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -315,11 +293,10 @@ pub mod scheduler_rpc_server {
                         let inner = inner.0;
                         let method = queryFlightSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            );
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -328,21 +305,12 @@ pub mod scheduler_rpc_server {
                 "/grpc.SchedulerRpc/confirmFlight" => {
                     #[allow(non_camel_case_types)]
                     struct confirmFlightSvc<T: SchedulerRpc>(pub Arc<T>);
-                    impl<T: SchedulerRpc> tonic::server::UnaryService<super::Id>
-                    for confirmFlightSvc<T> {
+                    impl<T: SchedulerRpc> tonic::server::UnaryService<super::Id> for confirmFlightSvc<T> {
                         type Response = super::ConfirmFlightResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::Id>,
-                        ) -> Self::Future {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::Id>) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move {
-                                (*inner).confirm_flight(request).await
-                            };
+                            let fut = async move { (*inner).confirm_flight(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -353,11 +321,10 @@ pub mod scheduler_rpc_server {
                         let inner = inner.0;
                         let method = confirmFlightSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            );
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -366,21 +333,12 @@ pub mod scheduler_rpc_server {
                 "/grpc.SchedulerRpc/cancelFlight" => {
                     #[allow(non_camel_case_types)]
                     struct cancelFlightSvc<T: SchedulerRpc>(pub Arc<T>);
-                    impl<T: SchedulerRpc> tonic::server::UnaryService<super::Id>
-                    for cancelFlightSvc<T> {
+                    impl<T: SchedulerRpc> tonic::server::UnaryService<super::Id> for cancelFlightSvc<T> {
                         type Response = super::CancelFlightResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::Id>,
-                        ) -> Self::Future {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::Id>) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move {
-                                (*inner).cancel_flight(request).await
-                            };
+                            let fut = async move { (*inner).cancel_flight(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -391,11 +349,10 @@ pub mod scheduler_rpc_server {
                         let inner = inner.0;
                         let method = cancelFlightSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            );
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -404,15 +361,9 @@ pub mod scheduler_rpc_server {
                 "/grpc.SchedulerRpc/isReady" => {
                     #[allow(non_camel_case_types)]
                     struct isReadySvc<T: SchedulerRpc>(pub Arc<T>);
-                    impl<
-                        T: SchedulerRpc,
-                    > tonic::server::UnaryService<super::ReadyRequest>
-                    for isReadySvc<T> {
+                    impl<T: SchedulerRpc> tonic::server::UnaryService<super::ReadyRequest> for isReadySvc<T> {
                         type Response = super::ReadyResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ReadyRequest>,
@@ -429,28 +380,23 @@ pub mod scheduler_rpc_server {
                         let inner = inner.0;
                         let method = isReadySvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            );
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        Ok(
-                            http::Response::builder()
-                                .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
-                                .body(empty_body())
-                                .unwrap(),
-                        )
-                    })
-                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
             }
         }
     }

--- a/server/src/grpc_client_wrapper.rs
+++ b/server/src/grpc_client_wrapper.rs
@@ -1,0 +1,147 @@
+use async_trait::async_trait;
+use svc_storage_client_grpc::client::flight_plan_rpc_client::FlightPlanRpcClient;
+use svc_storage_client_grpc::client::vehicle_rpc_client::VehicleRpcClient;
+use svc_storage_client_grpc::client::vertipad_rpc_client::VertipadRpcClient;
+use svc_storage_client_grpc::client::vertiport_rpc_client::VertiportRpcClient;
+use svc_storage_client_grpc::client::{
+    FlightPlan, FlightPlanData, FlightPlans, Id, SearchFilter, UpdateFlightPlan, Vehicles,
+    Vertiport, Vertiports,
+};
+use tonic::transport::Channel;
+use tonic::{Request, Response, Status};
+
+fn err_msg() -> Status {
+    Status::internal("Storage client not initialized")
+}
+
+#[derive(Debug)]
+pub struct GRPCClients {
+    pub flight_plan_client: FlightPlanRpcClient<Channel>,
+    pub vertiport_client: VertiportRpcClient<Channel>,
+    pub vertipad_client: VertipadRpcClient<Channel>,
+    pub vehicle_client: VehicleRpcClient<Channel>,
+}
+
+#[async_trait]
+pub trait StorageClientWrapperTrait {
+    async fn vertiports(
+        &self,
+        request: Request<SearchFilter>,
+    ) -> Result<Response<Vertiports>, Status>;
+    async fn vertiport_by_id(&self, request: Request<Id>) -> Result<Response<Vertiport>, Status>;
+    async fn flight_plan_by_id(&self, request: Request<Id>)
+        -> Result<Response<FlightPlan>, Status>;
+    async fn flight_plans(
+        &self,
+        request: Request<SearchFilter>,
+    ) -> Result<Response<FlightPlans>, Status>;
+    async fn insert_flight_plan(
+        &self,
+        request: Request<FlightPlanData>,
+    ) -> Result<Response<FlightPlan>, Status>;
+    async fn update_flight_plan(
+        &self,
+        request: Request<UpdateFlightPlan>,
+    ) -> Result<Response<FlightPlan>, Status>;
+    async fn vehicles(&self, request: Request<SearchFilter>) -> Result<Response<Vehicles>, Status>;
+}
+
+#[derive(Debug)]
+pub struct StorageClientWrapper {
+    pub grpc_clients: Option<GRPCClients>,
+}
+
+#[async_trait]
+impl StorageClientWrapperTrait for StorageClientWrapper {
+    async fn vertiports(
+        &self,
+        request: Request<SearchFilter>,
+    ) -> Result<Response<Vertiports>, Status> {
+        let mut vertiport_client = self
+            .grpc_clients
+            .as_ref()
+            .ok_or_else(|| err_msg())
+            .unwrap()
+            .vertiport_client
+            .clone();
+        vertiport_client.vertiports(request).await
+    }
+
+    async fn vertiport_by_id(&self, request: Request<Id>) -> Result<Response<Vertiport>, Status> {
+        let mut vertiport_client = self
+            .grpc_clients
+            .as_ref()
+            .ok_or_else(|| err_msg())
+            .unwrap()
+            .vertiport_client
+            .clone();
+        vertiport_client.vertiport_by_id(request).await
+    }
+
+    async fn flight_plan_by_id(
+        &self,
+        request: Request<Id>,
+    ) -> Result<Response<FlightPlan>, Status> {
+        let mut fp_client = self
+            .grpc_clients
+            .as_ref()
+            .ok_or_else(|| err_msg())
+            .unwrap()
+            .flight_plan_client
+            .clone();
+        fp_client.flight_plan_by_id(request).await
+    }
+
+    async fn flight_plans(
+        &self,
+        request: Request<SearchFilter>,
+    ) -> Result<Response<FlightPlans>, Status> {
+        let mut fp_client = self
+            .grpc_clients
+            .as_ref()
+            .ok_or_else(|| err_msg())
+            .unwrap()
+            .flight_plan_client
+            .clone();
+        fp_client.flight_plans(request).await
+    }
+
+    async fn insert_flight_plan(
+        &self,
+        request: Request<FlightPlanData>,
+    ) -> Result<Response<FlightPlan>, Status> {
+        let mut fp_client = self
+            .grpc_clients
+            .as_ref()
+            .ok_or_else(|| err_msg())
+            .unwrap()
+            .flight_plan_client
+            .clone();
+        fp_client.insert_flight_plan(request).await
+    }
+
+    async fn update_flight_plan(
+        &self,
+        request: Request<UpdateFlightPlan>,
+    ) -> Result<Response<FlightPlan>, Status> {
+        let mut fp_client = self
+            .grpc_clients
+            .as_ref()
+            .ok_or_else(|| err_msg())
+            .unwrap()
+            .flight_plan_client
+            .clone();
+        fp_client.update_flight_plan(request).await
+    }
+
+    async fn vehicles(&self, request: Request<SearchFilter>) -> Result<Response<Vehicles>, Status> {
+        let mut vehicle_client = self
+            .grpc_clients
+            .as_ref()
+            .ok_or_else(|| err_msg())
+            .unwrap()
+            .vehicle_client
+            .clone();
+        vehicle_client.vehicles(request).await
+    }
+}

--- a/server/src/queries.rs
+++ b/server/src/queries.rs
@@ -290,3 +290,54 @@ pub async fn cancel_flight(
         Err(Status::not_found(err_msg))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    mod test_utils {
+        include!("test_utils.rs");
+    }
+    use super::*;
+    use test_utils::*;
+
+    #[tokio::test]
+    async fn query_flight_test() {
+        let (serve_future, mut client) = vertiport_server_and_client_stub().await;
+
+        let request_future = async {
+            let id = "1".to_string();
+            let response = client
+                .vertiport_by_id(Request::new(StorageId { id: id.clone() }))
+                .await
+                .unwrap()
+                .into_inner();
+            // Validate server response with assertions
+            assert_eq!(response.id, id);
+        };
+
+        // Wait for completion, when the client request future completes
+        tokio::select! {
+            _ = serve_future => panic!("server returned first"),
+            _ = request_future => (),
+        }
+    }
+
+    /*#[test]
+    fn test_query_flight() {
+        query_flight(
+            Request::new(QueryFlightRequest {
+                is_cargo: false,
+                persons: None,
+                weight_grams: None,
+                departure_time: None,
+                arrival_time: None,
+                vertiport_depart_id: "".to_string(),
+                vertiport_arrive_id: "".to_string(),
+            }),
+            fp_client,
+            vehicle_client,
+            vertiport_client,
+        )
+        .unwrap();
+        assert_eq!(aw!(str_len_async("x5ff")), 4);
+    }*/
+}

--- a/server/src/test_utils.rs
+++ b/server/src/test_utils.rs
@@ -1,0 +1,104 @@
+/// gRPC test utils for creating gRPC server and client stubs
+/// Tonic server and client stubs as per this SO answer:
+/// https://stackoverflow.com/questions/69845664/how-to-integration-test-tonic-application
+/// and this tonic test example:
+/// https://github.com/hyperium/tonic/blob/dee2ab52ff4a2995156a3baf5ea916b479fd1d14/tests/integration_tests/tests/connect_info.rs
+use router::location::Location;
+use std::future::Future;
+use std::sync::Arc;
+use svc_storage_client_grpc::client::{
+    vehicle_rpc_client::VehicleRpcClient,
+    vertiport_rpc_client::VertiportRpcClient,
+    vertiport_rpc_server::{VertiportRpc, VertiportRpcServer},
+    Id as StorageId, SearchFilter, UpdateVertiport, Vertiport, VertiportData, Vertiports,
+};
+use tempfile::NamedTempFile;
+use tokio::net::{UnixListener, UnixStream};
+use tokio_stream::wrappers::UnixListenerStream;
+use tonic::transport::{Channel, Endpoint, Server, Uri};
+use tonic::{Request, Response, Status};
+use tower::service_fn;
+
+struct VertiportServerStub {}
+
+#[tonic::async_trait]
+impl VertiportRpc for VertiportServerStub {
+    async fn vertiports(
+        &self,
+        request: Request<SearchFilter>,
+    ) -> Result<Response<Vertiports>, Status> {
+        todo!()
+    }
+
+    async fn vertiport_by_id(
+        &self,
+        request: Request<StorageId>,
+    ) -> Result<Response<Vertiport>, Status> {
+        if request.into_inner().id == "1" {
+            Ok(Response::new(Vertiport {
+                id: "1".to_string(),
+                data: Some(VertiportData {
+                    description: "".to_string(),
+                    latitude: 0.0,
+                    longitude: 0.0,
+                    schedule: None,
+                }),
+            }))
+        } else {
+            Err(Status::not_found("Not found"))
+        }
+    }
+
+    async fn insert_vertiport(
+        &self,
+        request: Request<VertiportData>,
+    ) -> Result<Response<Vertiport>, Status> {
+        todo!()
+    }
+
+    async fn update_vertiport(
+        &self,
+        request: Request<UpdateVertiport>,
+    ) -> Result<Response<Vertiport>, Status> {
+        todo!()
+    }
+
+    async fn delete_vertiport(&self, request: Request<StorageId>) -> Result<Response<()>, Status> {
+        todo!()
+    }
+}
+
+pub async fn vertiport_server_and_client_stub(
+) -> (impl Future<Output = ()>, VertiportRpcClient<Channel>) {
+    let socket = NamedTempFile::new().unwrap();
+    let socket = Arc::new(socket.into_temp_path());
+    std::fs::remove_file(&*socket).unwrap();
+
+    let uds = UnixListener::bind(&*socket).unwrap();
+    let stream = UnixListenerStream::new(uds);
+
+    let serve_future = async {
+        let result = Server::builder()
+            .add_service(VertiportRpcServer::new(VertiportServerStub {}))
+            .serve_with_incoming(stream)
+            .await;
+        // Server must be running fine...
+        assert!(result.is_ok());
+    };
+
+    let socket = Arc::clone(&socket);
+    // Connect to the server over a Unix socket
+    // The URL will be ignored.
+    let channel = Endpoint::try_from("http://any.url")
+        .unwrap()
+        .connect_with_connector(service_fn(move |_: Uri| {
+            let socket = Arc::clone(&socket);
+            async move { UnixStream::connect(&*socket).await }
+        }))
+        .await
+        .unwrap();
+
+    let client = VertiportRpcClient::new(channel);
+
+    (serve_future, client)
+}


### PR DESCRIPTION
Added unit test using stub of vertiport grpc server and client and unix sockets.

More info why this is needed:
https://stackoverflow.com/questions/69845664/how-to-integration-test-tonic-application

This is similar test setup done by tonic themselves:
https://github.com/hyperium/tonic/blob/dee2ab52ff4a2995156a3baf5ea916b479fd1d14/tests/integration_tests/tests

Other issue is that this testing requires not only grpc client exposed, but server too, so svc-storage-grpc-client needs to build and expose both client and server implementations
